### PR TITLE
🔄 Build: migrate from poetry to setuptools with uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,33 @@
 # DatasetPlus
 
-Enhanced dataset management utilities for Hugging Face Hub, with support for audio data processing.
+Enhanced dataset management utilities for the Hugging Face Hub.
 
 ## Installation
 
 ```bash
-# Install from PyPI
-uv pip install datasetplus
-
-# Or install from source
-git clone https://github.com/kadirnar/datasetplus.git
-cd datasetplus
-uv pip install ".[dev]"
+uv pip install -e .
 ```
 
-## Features
+## Usage Examples
 
-- Easy dataset download from Hugging Face Hub
-- Audio data processing from Parquet files
-- Colored logging system
-- Progress tracking
-
-## Quick Start
+### Download a Dataset
 
 ```python
-from datasetplus import HFDatasetManager, AudioProcessor
+from datasetplus import Dataset
 
-# Download dataset
-dataset = HFDatasetManager()
+dataset = Dataset()
 dataset.download(
     repo_id="fixie-ai/llama-questions",
     local_dir="output/llama_questions",
     repo_type="dataset",
 )
-
-# Process audio data
-processor = AudioProcessor("path/to/parquet")
-metadata = processor.get_metadata()
-audio_files = processor.extract_audio_files("output_dir", limit=5)
 ```
 
-## Development Setup
+### Process Audio Data
 
-1. Clone the repository:
+```python
+from datasetplus import AudioProcessor
 
-```bash
-git clone https://github.com/kadirnar/datasetplus.git
-cd datasetplus
+processor = AudioProcessor("path/to/audio/files")
+processor.process()
 ```
-
-2. Install dependencies with Poetry:
-
-```bash
-# Install Poetry if you haven't already
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Install dependencies
-poetry install
-```
-
-3. Set up pre-commit hooks:
-
-```bash
-# Install pre-commit if you haven't already
-pip install pre-commit
-
-# Install the pre-commit hooks
-pre-commit install
-
-# Run pre-commit on all files
-pre-commit run --all-files
-```
-
-The pre-commit hooks will automatically:
-
-- Format code with Ruff
-- Run type checking with mypy
-- Check for common issues with pre-commit hooks
-
-## Code Style
-
-This project uses:
-
-- Ruff for code formatting and linting (replacing Black, isort, and flake8)
-- mypy for type checking
-
-Ruff is configured to:
-
-- Follow Black-compatible formatting
-- Check import sorting
-- Enforce docstring standards
-- Check for common code issues
-- Apply automatic fixes when possible
-
-All of these are automatically run via pre-commit hooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,41 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
 
-[tool.poetry]
+[project]
 name = "datasetplus"
 version = "0.1.0"
-description = "Enhanced dataset management utilities for Hugging Face Hub"
-authors = ["Kadir Nar <kadir.nar@gmail.com>"]
-maintainers = ["Kadir Nar <kadir.nar@gmail.com>"]
+description = "Enhanced dataset management utilities for the Hugging Face Hub"
+authors = [{name = "Kadir Nar", email = "kadir.nar@hotmail.com"}]
 readme = "README.md"
-license = "MIT"
-homepage = "https://github.com/kadirnar/datasetplus"
-repository = "https://github.com/kadirnar/datasetplus"
-documentation = "https://github.com/kadirnar/datasetplus"
-keywords = ["dataset", "huggingface", "audio", "machine learning"]
-packages = [
-    { include = "datasetplus" }
+license = {text = "Apache-2.0"}
+requires-python = ">=3.9,<4.0"
+dependencies = [
+    "huggingface-hub>=0.19.0",
+    "polars>=0.19.12",
+    "colorlog>=6.7.0",
+    "tqdm>=4.66.1",
 ]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.3",
+    "mypy>=1.7.1",
+    "ruff>=0.1.8",
+    "pre-commit>=3.5.0",
+    "types-requests>=2.31.0.10",
+    "types-setuptools>=69.0.0.0",
+    "types-tqdm>=4.66.0.2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/kadirnar/datasetplus"
+Repository = "https://github.com/kadirnar/datasetplus"
+Documentation = "https://github.com/kadirnar/datasetplus"
 
 [tool.ruff]
 line-length = 100
 target-version = "py39"
-
-# Enable Pyflakes `F` and `E`, `W` series
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "T20", "RET", "SIM", "D"]
 ignore = [
     "D203",  # one-blank-line-before-class
@@ -65,16 +66,3 @@ warn_no_return = true
 warn_unreachable = true
 strict_equality = true
 ignore_missing_imports = true
-
-[tool.poetry.dependencies]
-python = ">=3.9,<4.0"
-huggingface-hub = ">=0.19.0"
-tqdm = ">=4.65.0"
-polars = ">=0.20.1"
-colorlog = ">=6.7.0"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.4.3"
-mypy = "^1.7.1"
-ruff = "^0.1.8"
-pre-commit = "^3.6.0"


### PR DESCRIPTION
✨ Switch to modern Python packaging:
🔧 Replace poetry with setuptools in pyproject.toml 📦 Update dependencies to use standard PEP 621 format 📝 Simplify README with uv-based installation
🗑️ Remove poetry-specific configurations